### PR TITLE
Add support for command line remote repos for Maven resolution

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -156,7 +156,13 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>3.8.1</version>
+      <version>4.10</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+      <version>2.6</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/site/apt/examples/mvn.apt.vm
+++ b/src/site/apt/examples/mvn.apt.vm
@@ -71,6 +71,18 @@ Running the Mvn Task without a Maven Installation
 
   <<Note: this will use version ${mavenVersion} of the core Maven libraries, contained in the Maven Ant Tasks jar>>
 
+  To obtain the required Maven files, the task needs to resolve them from a remote repository. The default repository as defined in
+  org.apache.maven:maven-project:2.2.1 is used (http://repo1.maven.org/maven2), but this is not available on http anymore
+  since 15 January 2020. Until we can use a newer version of maven-project, we have introduced the possibility to specify the remote
+  repositories to use for resolution, as a command line argument (-DremoteRepositories=<repo1>,<repo2>,...). Each repo can use the short
+  format (only the url) or the long format (id::layout::url).
+
+-----
+  <artifact:mvn pom="path/to/my-pom.xml">
+    <arg line="-DoutputDirectory=output -DremoteRepositories=myrepo::default::https://repo1.maven.org/maven2/"/>
+  </artifact:mvn>
+-----
+
 Using the Java Task
 
   The java task can be used directly without any need for the Maven Ant Tasks. However,

--- a/src/test/java/org/apache/maven/artifact/ant/MvnTest.java
+++ b/src/test/java/org/apache/maven/artifact/ant/MvnTest.java
@@ -1,0 +1,69 @@
+package org.apache.maven.artifact.ant;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.tools.ant.Project;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.File;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+public class MvnTest
+{
+
+    private static final String ROOT_RESOURCES_PATH = "target/test-classes/mvnTest/";
+    private static final String POM_PATH = ROOT_RESOURCES_PATH + "external-dependencies.xml";
+    private static final String OUTPUT_PATH = "output/libs"; // needs to be relative to the external-dependencies.xml file
+
+    private static final String MVN_VERSION = "3.2.5";
+
+    private Mvn task = new Mvn();
+
+    private File outputDir;
+
+    @Before
+    public void setUp()
+    {
+        File pom = new File(POM_PATH);
+        task.setPom(pom);
+
+        task.setFork(true);
+        task.setFailonerror(true);
+        task.setMavenVersion(MVN_VERSION);
+        task.setArgs("dependency:copy-dependencies -DoutputDirectory=" + OUTPUT_PATH
+            + " -DoverWriteReleases=true -DoverWriteSnapshots=true -DoverWriteIfNewer=true -DexcludeTransitive=true"
+            + " -DremoteRepositories=swa::default::https://repo1.maven.org/maven2,swa_http::default::http://repo1.maven.org/maven2"
+        );
+
+        Project project = new Project();
+        project.setName("mvnTest");
+        task.setProject(project);
+
+        outputDir = new File(ROOT_RESOURCES_PATH + OUTPUT_PATH);
+        //noinspection ResultOfMethodCallIgnored
+        outputDir.mkdirs();
+    }
+
+    @Test
+    public void testExecuteTask()
+    {
+        task.execute();
+
+        assertTrue(outputDir.exists());
+
+        String[] outputContent = outputDir.list();
+        assertNotNull(outputContent);
+        assertEquals(1, outputContent.length);
+        assertEquals("commons-math3-3.6.1.jar", outputContent[0]);
+    }
+
+    @After
+    public void tearDown()
+    {
+        FileUtils.deleteQuietly(outputDir);
+    }
+}

--- a/src/test/resources/mvnTest/external-dependencies.xml
+++ b/src/test/resources/mvnTest/external-dependencies.xml
@@ -1,0 +1,17 @@
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.test</groupId>
+    <artifactId>testMvnArtefact</artifactId>
+    <version>1.0.0</version>
+
+    <packaging>jar</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-math3</artifactId>
+            <version>3.6.1</version>
+        </dependency>
+    </dependencies>
+</project>


### PR DESCRIPTION
Added command line parameter for the remote repositories used by the Mvn task to resolve Maven itself when there is no local installation.

Based on the emails exchange on the devs list with sitnikov.vladimir@gmail.com.