### PR TITLE
Use https for maven repo

### DIFF
--- a/build-tests.xml
+++ b/build-tests.xml
@@ -219,7 +219,7 @@
     <artifact:dependencies>
       <dependency groupId="geronimo-spec" artifactId="geronimo-spec-javamail" version="1.3.1-rc5" />
       <localRepository path="${basedir}/target/local-repo-legacy" />
-      <remoteRepository url="http://repo1.maven.org/maven" layout="legacy" id="central" />
+      <remoteRepository url="https://repo1.maven.org/maven" layout="legacy" id="central" />
     </artifact:dependencies>
   </target>
 
@@ -233,7 +233,7 @@
       <dependency groupId="it.ant-tasks" artifactId="snapshotUniqueFalse" version="2.0.7-SNAPSHOT"/>
       <dependency groupId="it.ant-tasks" artifactId="snapshotUniqueTrue" version="2.0.7-SNAPSHOT"/>
       <localRepository refid="local.repository"/>
-      <remoteRepository url="http://repo1.maven.org/maven2" id="central" />
+      <remoteRepository url="https://repo1.maven.org/maven2" id="central" />
       <remoteRepository url="file://${user.dir}/src/test/repo" id="test.repo">
         <snapshots enabled="true"/>
         <releases enabled="false"/>
@@ -361,7 +361,7 @@
       <dependency groupId="junit" artifactId="junit" version="3.8.1"/>
       <dependency groupId="it.ant-tasks" artifactId="snapshotUniqueFalse" version="2.0.7-SNAPSHOT"/>
       <localRepository refid="local.repository"/>
-      <remoteRepository url="http://repo1.maven.org/maven2" id="central" />
+      <remoteRepository url="https://repo1.maven.org/maven2" id="central" />
       <remoteRepository url="file://${user.dir}/src/test/repo" id="test.repo">
         <snapshots enabled="true"/>
         <releases enabled="false"/>
@@ -380,7 +380,7 @@
       <dependency groupId="it.ant-tasks" artifactId="snapshotUniqueFalse" version="2.0.7-SNAPSHOT"/>
       <dependency groupId="junit" artifactId="junit" version="3.8.1"/>
       <localRepository refid="local.repository"/>
-      <remoteRepository url="http://repo1.maven.org/maven2" id="central" />
+      <remoteRepository url="https://repo1.maven.org/maven2" id="central" />
       <remoteRepository url="file://${user.dir}/src/test/repo" id="test.repo">
         <snapshots enabled="true"/>
         <releases enabled="false"/>

--- a/src/main/java/org/apache/maven/artifact/ant/AbstractArtifactWithRepositoryTask.java
+++ b/src/main/java/org/apache/maven/artifact/ant/AbstractArtifactWithRepositoryTask.java
@@ -52,7 +52,7 @@ public abstract class AbstractArtifactWithRepositoryTask
         // TODO: could we utilize the super POM for this?
         RemoteRepository remoteRepository = new RemoteRepository();
         remoteRepository.setId( "central" );
-        remoteRepository.setUrl( "http://repo1.maven.org/maven2" );
+        remoteRepository.setUrl( "https://repo1.maven.org/maven2" );
         RepositoryPolicy snapshots = new RepositoryPolicy();
         snapshots.setEnabled( false );
         remoteRepository.addSnapshots( snapshots );

--- a/src/site/apt/usage.apt
+++ b/src/site/apt/usage.apt
@@ -98,7 +98,7 @@ Using Maven Ant Tasks
 </artifact:dependencies>
 -----
 
-  The default {{{http://repo1.maven.org/maven2/} central}} repository is automatically added to remote repositories.
+  The default {{{https://repo1.maven.org/maven2/} central}} repository is automatically added to remote repositories.
   Until 2.0.10, if at least one remote repository was specified, central was not automatically added: you had
   to declare it if you needed it.
 


### PR DESCRIPTION
Maven central moved to require https access
https://blog.sonatype.com/central-repository-moving-to-https